### PR TITLE
Parse api combinations

### DIFF
--- a/client/src/components/PlaidForm/CompoundForm.jsx
+++ b/client/src/components/PlaidForm/CompoundForm.jsx
@@ -119,8 +119,6 @@ const setUpTheCompoundForm = (groupObj) => {
       utilGroup.compound_concentration_indicators,
     groups: groupObj,
   };
-  console.log(compoundObject);
-
   return compoundObject;
 };
 

--- a/client/src/components/PlaidForm/CompoundForm.jsx
+++ b/client/src/components/PlaidForm/CompoundForm.jsx
@@ -151,6 +151,10 @@ const CompoundForm = ({
           value: compoundForm.groups,
           message: "Compound names must be unique. You have multiples of the following: ",
         },
+        isCombination: {
+          value: compoundForm.groups,
+          message: "Parenthesis is reserved for combinations or wrap single compounds"
+        }
       },
       concentration_names: {
         concNameCount: {

--- a/client/src/components/PlaidForm/Validation/useValidation.jsx
+++ b/client/src/components/PlaidForm/Validation/useValidation.jsx
@@ -44,7 +44,7 @@ const validators = {
   },
   isAlsoChecked: function (config) {
     return function (value) {
-      if (config.value == true && value == true) {
+      if (config.value === true && value === true) {
         return config.message;
       }
       return null;
@@ -111,7 +111,7 @@ const validators = {
           return null;
         }
 
-        if ((group.control_names === "" || group.concentration_names === "") || (group.control_names !== "" && group.concentration_names !== "")
+        if (((group.control_names === "" || group.concentration_names === "") || (group.control_names !== "" && group.concentration_names !== ""))
           && parseInt(group.control_replicates) < 1) {
           return config.message;
         }
@@ -171,9 +171,9 @@ const validators = {
     const compoundForm = config.value.compoundForm;
     const controlForm = config.value.controlForm;
     return function () {
-      
+
       let denom = 1;
-      if(experimentForm.horizontal_cell_lines == 1 || experimentForm.vertical_cell_lines == 1){
+      if (experimentForm.horizontal_cell_lines === 1 || experimentForm.vertical_cell_lines === 1) {
         denom = Math.max(experimentForm.horizontal_cell_lines, experimentForm.vertical_cell_lines);
       } else {
         denom = experimentForm.horizontal_cell_lines + experimentForm.vertical_cell_lines;
@@ -188,8 +188,8 @@ const validators = {
       const numCompoundReplicates = compoundForm.compound_replicates.reduce((a, b) => a + b, 0);
       const wellsLeft = numWells - amountEmptyWells - controlForm.num_controls - numCompoundReplicates
         - compoundForm.compounds - numControlReplicates;
-        
-      if(wellsLeft < 0){
+
+      if (wellsLeft < 0) {
         return config.message.tooFewWells;
       }
 
@@ -216,8 +216,6 @@ const validators = {
           dupes[mergedArrays[i]] = mergedArrays[i];
         }
       }
-      console.log(dupes.length);
-
       if (Object.keys(dupes).length > 0) {
         let dupe_str = Object.keys(dupes).join(',');
         return config.message + `${dupe_str}`
@@ -227,7 +225,7 @@ const validators = {
   },
   ctrlDuplicates: function (config) {
     return function () {
-      let groups = config.value.groups;
+      const groups = config.value.groups;
       let noDupes = {};
       let dupes = {};
       let mergedArrays = [];
@@ -242,7 +240,6 @@ const validators = {
           dupes[mergedArrays[i]] = mergedArrays[i];
         }
       }
-      console.log(dupes.length);
 
       if (Object.keys(dupes).length > 0) {
         let dupe_str = Object.keys(dupes).join(',');
@@ -251,15 +248,27 @@ const validators = {
       return null;
     }
   },
-  maxWellInput: function (config) {
+  isCombination: function (config) {
     return function () {
-      //calculate number of total wells.
-      //calculate wells representing number of horizontal and vertical lines.
-      //If empty wells allowed, account for it.
-      //If empty wells are not allowed, take all wells and subtract with all compounds, vert & horiztonal lines, replicates and controls. This must be 0. If it's negative, it's too many. If it's positive, too few
-      //If they are allowed, take all wells, subtract with all compounds, vert & horizontal lines. This can be a number >= 0.
+      const groups = config.value.groups;
+      let mergedArrays = [];
+      const regex = RegExp(/^\w*(?<!.)(\([^\(\)]+\)){1,4}(?=$)/);
 
-
+      for (let i = 0; i < groups.length; i++) {
+        mergedArrays = mergedArrays.concat(groups[i].compound_names_parsed);
+      }
+      console.log(mergedArrays);
+      for(let i = 0; i < mergedArrays.length; i++){
+        let str = mergedArrays[i];
+        if(str.includes("(") || str.includes(")")){
+          console.log(regex.test(str))
+          if(!regex.test(str)){
+            return config.message;
+          }
+        }
+        
+      }
+      return null;
     }
   }
 };

--- a/client/src/components/PlaidForm/Validation/useValidation.jsx
+++ b/client/src/components/PlaidForm/Validation/useValidation.jsx
@@ -208,11 +208,18 @@ const validators = {
       for (let i = 0; i < groups.length; i++) {
         mergedArrays = mergedArrays.concat(groups[i].compound_names_parsed);
       }
+   /*    for(let i = 0; i < mergedArrays.length; i++){
+        if(mergedArrays.includes('('+mergedArrays[i]+')')){
+          return config.message + `${mergedArrays}`; 
+        }
+      } */
       for (let i = 0; i < mergedArrays.length; i++) {
         if (noDupes[mergedArrays[i]] === undefined) {
           noDupes[mergedArrays[i]] = mergedArrays[i];
+          noDupes['('+mergedArrays[i]+')'] = mergedArrays[i];
         }
         else {
+          
           dupes[mergedArrays[i]] = mergedArrays[i];
         }
       }
@@ -252,21 +259,17 @@ const validators = {
     return function () {
       const groups = config.value.groups;
       let mergedArrays = [];
-      const regex = RegExp(/^\w*(?<!.)(\([^\(\)]+\)){1,4}(?=$)/);
-
+      const regex = RegExp(/^\w*(?<!.)(\([^\(\)\s\t]+\)){1,4}(?=$)/)
       for (let i = 0; i < groups.length; i++) {
         mergedArrays = mergedArrays.concat(groups[i].compound_names_parsed);
       }
-      console.log(mergedArrays);
       for(let i = 0; i < mergedArrays.length; i++){
         let str = mergedArrays[i];
         if(str.includes("(") || str.includes(")")){
-          console.log(regex.test(str))
           if(!regex.test(str)){
             return config.message;
           }
         }
-        
       }
       return null;
     }

--- a/client/src/components/PlateLayout/PlateLayout.jsx
+++ b/client/src/components/PlateLayout/PlateLayout.jsx
@@ -35,15 +35,48 @@ const assignColorToCompound = (concs, hue, compoundToColorMap) => {
         o.cmpdnum,
         i === 0
           ? /*  tweak colors here if needed */
-            `hsla(${hue},${70}%,${40}%,0.84)`
+          `hsla(${hue},${70}%,${40}%,0.84)`
           : `hsla(${hue},${100}%,${40 + (i / 2) * 5}%,0.90)`
       );
       i++;
     }
   }
 };
+const split_parenthesis = (str) => {
+  let arr = [];
+  let start, end;
+  for (let i = 0; i < str.length; i++) {
+
+    if (str.charAt(i) === "(") {
+      start = i;
+    }
+    if (str.charAt(i) === ")") {
+      end = i + 1;
+      arr.push(str.substring(start, end))
+    }
+  }
+  return arr;
+}
 const find_combinations = (data) => {
-  
+  let combinations = {}
+  let compounds = {}
+  const regex = RegExp(/^\w*(?<!.)(\([^\(\)\s\t]+\)){1,4}(?=$)/)
+
+  for (let i = 0; i < data.length; i++) {
+    for (let key in data[i]) {
+      if (key === 'cmpdname') {
+         compounds[data[i][key]] = data[i][key];
+      }
+    }
+  }
+
+  for (let key in compounds) {
+    console.log(key);
+    if (regex.test(compounds[key])) {
+      combinations[key] = split_parenthesis(compounds[key]);
+    }
+  }
+  console.log(combinations);
 }
 
 /**
@@ -56,7 +89,7 @@ const find_combinations = (data) => {
  */
 const PlateLayout = (props) => {
 
-  const combinations = find_combinations(props.data)
+  const combinations = find_combinations(props.data);
   /* rowList, colList used to map over in the return as to render each component */
   /* There is no way to use a loop in JSX hence this "hack" */
   let rowList = [];
@@ -126,7 +159,7 @@ const PlateLayout = (props) => {
           cols={props.cols}
           sizeEmptyEdge={props.sizeEmptyEdge}
           type={"json"}
-        />  
+        />
       </StyledDownloadButtonContainer>
       {plates.map((data, index) => {
         return (

--- a/client/src/components/PlateLayout/PlateLayout.jsx
+++ b/client/src/components/PlateLayout/PlateLayout.jsx
@@ -42,6 +42,9 @@ const assignColorToCompound = (concs, hue, compoundToColorMap) => {
     }
   }
 };
+const find_combinations = (data) => {
+  
+}
 
 /**
  * Renders the container that holds the (or all) resulting plates.
@@ -52,6 +55,8 @@ const assignColorToCompound = (concs, hue, compoundToColorMap) => {
  * @param props.sizeEmptyEdge the amount of empty edges in the plate specified in the form
  */
 const PlateLayout = (props) => {
+
+  const combinations = find_combinations(props.data)
   /* rowList, colList used to map over in the return as to render each component */
   /* There is no way to use a loop in JSX hence this "hack" */
   let rowList = [];

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5041,7 +5041,7 @@ file-loader@6.1.1:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
 
-"file-saver@github:eligrey/FileSaver.js#1.3.8":
+file-saver@eligrey/FileSaver.js#1.3.8:
   version "1.3.8"
   resolved "https://codeload.github.com/eligrey/FileSaver.js/tar.gz/e865e37af9f9947ddcced76b549e27dc45c1cb2e"
 


### PR DESCRIPTION
1. Compounds can now contain combinations in the form (a)(b) or single compounds (a). 
2. Validation added in order to not allow (a) and a as they are considered duplicates 
3.  Validation added to stop weird parenthesis usage, e.g ( )), (), ( ), a(b etc.
4. Function added to api to parse compound names from the API. It returns an object { (a)(b): [(a),(b)} 